### PR TITLE
[Feat] add Angular directory parser and models

### DIFF
--- a/reagent/core/__init__.py
+++ b/reagent/core/__init__.py
@@ -19,6 +19,19 @@ class REAgent:
     validator: ValidatorProtocol
 
     def run_pipeline(self, path: Path) -> NormalizedModel:
+        """Run the full ingestion pipeline on ``path``.
+
+        Parameters
+        ----------
+        path: Path
+            Location of the source artifact to parse.
+
+        Returns
+        -------
+        NormalizedModel
+            The validated model produced from ``path``.
+        """
+
         artifact = self.parser.parse(path)
         model = self.handler.handle(artifact)
         self.validator.validate(model)

--- a/reagent/handler/__init__.py
+++ b/reagent/handler/__init__.py
@@ -11,6 +11,19 @@ class AngularJSFormHandler(HandlerProtocol):
     field_pattern = re.compile(r"ng-model=\"([a-zA-Z0-9_\.]+)\"")
 
     def handle(self, artifact: ParsedArtifact) -> NormalizedModel:
+        """Produce a :class:`NormalizedModel` from ``artifact``.
+
+        Parameters
+        ----------
+        artifact: ParsedArtifact
+            Parsed HTML template.
+
+        Returns
+        -------
+        NormalizedModel
+            Model containing any ``ng-model`` field names.
+        """
+
         fields = self.field_pattern.findall(artifact.content)
         return NormalizedModel(fields=fields)
 

--- a/reagent/models/__init__.py
+++ b/reagent/models/__init__.py
@@ -1,9 +1,18 @@
 """Re-export commonly used models for convenience."""
 
 from ..protocols import ParsedArtifact, NormalizedModel, ValidationMessage
+from .angular import (
+    AngularComponentModel,
+    AngularControllerModel,
+    AngularTemplateModel,
+)
 
 __all__ = [
     "ParsedArtifact",
     "NormalizedModel",
     "ValidationMessage",
+    "AngularTemplateModel",
+    "AngularControllerModel",
+    "AngularComponentModel",
 ]
+

--- a/reagent/models/angular.py
+++ b/reagent/models/angular.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import NormalizedModel
+
+
+@dataclass
+class AngularTemplateModel:
+    """Normalized representation of an AngularJS HTML template."""
+
+    path: Path
+    model: NormalizedModel
+
+
+@dataclass
+class AngularControllerModel:
+    """Representation of an AngularJS controller file."""
+
+    path: Path
+    content: str
+
+
+@dataclass
+class AngularComponentModel:
+    """Group of template and controller describing a component."""
+
+    name: str
+    template: AngularTemplateModel
+    controller: AngularControllerModel | None = None

--- a/reagent/parser/__init__.py
+++ b/reagent/parser/__init__.py
@@ -3,12 +3,28 @@ from __future__ import annotations
 from pathlib import Path
 
 from ..protocols import ParserProtocol, ParsedArtifact
+from .actions import ParserAction, ResourceBundle
+
+__all__ = ["AngularJSParser", "ParserAction", "ResourceBundle"]
 
 
 class AngularJSParser(ParserProtocol):
     """Very small parser that reads an AngularJS artifact."""
 
     def parse(self, path: Path) -> ParsedArtifact:
+        """Parse ``path`` into a :class:`ParsedArtifact`.
+
+        Parameters
+        ----------
+        path: Path
+            File to load.
+
+        Returns
+        -------
+        ParsedArtifact
+            Representation of ``path`` and its textual content.
+        """
+
         text = path.read_text()
         return ParsedArtifact(source_path=path, content=text)
 

--- a/reagent/parser/actions.py
+++ b/reagent/parser/actions.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+from ..protocols import (
+    HandlerProtocol,
+    ParserProtocol,
+    ValidatorProtocol,
+)
+from ..models import (
+    AngularComponentModel,
+    AngularControllerModel,
+    AngularTemplateModel,
+)
+
+
+@dataclass
+class ResourceBundle:
+    """Collection of files representing an AngularJS component."""
+
+    template: Path
+    controller: Path | None = None
+
+
+class ParserAction:
+    """Parse a directory of AngularJS resources into component models."""
+
+    def __init__(
+        self,
+        parser: ParserProtocol,
+        handler: HandlerProtocol,
+        validator: ValidatorProtocol,
+    ) -> None:
+        self.parser = parser
+        self.handler = handler
+        self.validator = validator
+
+    def parse_directory(self, directory: Path) -> List[AngularComponentModel]:
+        """Parse ``directory`` and return component models."""
+
+        components: List[AngularComponentModel] = []
+        for html_file in directory.glob("*.html"):
+            js_file = html_file.with_suffix(".js")
+            bundle = ResourceBundle(
+                template=html_file, controller=js_file if js_file.exists() else None
+            )
+            artifact = self.parser.parse(bundle.template)
+            model = self.handler.handle(artifact)
+            self.validator.validate(model)
+            template_model = AngularTemplateModel(path=bundle.template, model=model)
+            controller_model = None
+            if bundle.controller:
+                controller_model = AngularControllerModel(
+                    path=bundle.controller, content=bundle.controller.read_text()
+                )
+            components.append(
+                AngularComponentModel(
+                    name=html_file.stem,
+                    template=template_model,
+                    controller=controller_model,
+                )
+            )
+        return components

--- a/tests/test_parser_action.py
+++ b/tests/test_parser_action.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import shutil
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from reagent.parser import ParserAction
+from reagent import REAgent
+from reagent_config import CONFIG
+
+SAMPLE_HTML = Path(__file__).with_name("sample_angularjs_form.html")
+SAMPLE_JS = Path(__file__).with_name("sample_angularjs_form.js")
+
+
+def test_parser_action(tmp_path: Path) -> None:
+    target_dir = tmp_path / "comp"
+    target_dir.mkdir()
+    shutil.copy(SAMPLE_HTML, target_dir / SAMPLE_HTML.name)
+    shutil.copy(SAMPLE_JS, target_dir / SAMPLE_JS.name)
+
+    agent = REAgent(CONFIG.parser, CONFIG.handler, CONFIG.validator)
+    action = ParserAction(agent.parser, agent.handler, agent.validator)
+    components = action.parse_directory(target_dir)
+    assert len(components) == 1
+    component = components[0]
+    assert component.template.model.fields == ["user.name", "user.email"]
+    assert component.controller is not None
+
+


### PR DESCRIPTION
## Summary
- document public pipeline methods
- implement `ParserAction` for directory parsing
- model AngularJS components, controllers, and templates
- expose new models in package
- add unit test for `ParserAction`

## Testing Done
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a8a0aa2c0832eb80a22eeeb7122f8